### PR TITLE
Fix sentry icon, add domains to some servers

### DIFF
--- a/servers/atlassian/server.json
+++ b/servers/atlassian/server.json
@@ -4,6 +4,7 @@
   "transport": [
     "sse"
   ],
+  "domains": ["atlassian.com"],
   "icon": "./icon.svg",
   "oauth": false,
   "config": {

--- a/servers/heroku/server.json
+++ b/servers/heroku/server.json
@@ -5,6 +5,7 @@
     "stdio"
   ],
   "icon": "./icon.svg",
+  "domains": ["heroku.com"],
   "oauth": false,
   "config": {
     "command": "npx",

--- a/servers/linear/server.json
+++ b/servers/linear/server.json
@@ -6,6 +6,7 @@
     "sse"
   ],
   "icon": "./icon.svg",
+  "domains": ["linear.app"],
   "oauth": true,
   "config": {
     "url": "https://mcp.linear.app/sse"

--- a/servers/notion/server.json
+++ b/servers/notion/server.json
@@ -4,6 +4,7 @@
   "transport": [
     "sse"
   ],
+  "domains": ["notion.so"],
   "icon": "./icon.svg",
   "oauth": true,
   "config": {

--- a/servers/sentry/icon.svg
+++ b/servers/sentry/icon.svg
@@ -1,7 +1,6 @@
 <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 50 44"
-    {...props}
   >
     <path
       fill="currentColor"

--- a/servers/sentry/server.json
+++ b/servers/sentry/server.json
@@ -4,6 +4,7 @@
   "transport": [
     "sse"
   ],
+  "domains": ["sentry.io"],
   "icon": "./icon.svg",
   "oauth": true,
   "config": {


### PR DESCRIPTION
I want to unify the api we use for detecting MCP servers at domains with the one we use for featured mcp servers so this adds an array of domains to some servers so when a user pastes a notion-dot-com link in the composer, we can suggest the notion mcp to them