### PR TITLE
docs: add links for server request template, discussions, and contributing

### DIFF
--- a/.github/ISSUE_TEMPLATE/server-request.yml
+++ b/.github/ISSUE_TEMPLATE/server-request.yml
@@ -118,7 +118,7 @@ body:
     attributes:
       label: Submission Guidelines
       options:
-        - label: Read the [Contributing Guidelines](CONTRIBUTING.md)
+        - label: Read the [Contributing Guidelines](https://github.com/cursor/mcp-servers/blob/main/CONTRIBUTING.md)
           required: true
         - label: Searched existing issues and servers to avoid duplicates
           required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Accepted MCP servers provide value to developers:
 
 ### Request a server
 
-Submit MCP servers via [server request template](https://github.com/your-username/mcp-servers/issues/new/choose). All technical integration and testing is handled for you.
+Submit MCP servers via the [Server Request Template](https://github.com/cursor/mcp-servers/issues/new?template=server-request.yml). All technical integration and testing is handled for you.
 
 This collection is curated. Servers must be useful to developers and work with professional development tools.
 
@@ -49,4 +49,4 @@ We process requests as fast as possible, but can't promise any timeline.
 
 ## Questions?
 
-Check existing [issues](https://github.com/cursor/mcp-servers/issues) or submit via repository discussions.
+Check existing [issues](https://github.com/cursor/mcp-servers/issues) or submit via repository [discussions](https://github.com/cursor/mcp-servers/discussions).


### PR DESCRIPTION
- Use absolute GitHub URL for Contributing link in .github/ISSUE_TEMPLATE/server-request.yml
- Update CONTRIBUTING “Server Request” link to GitHub issue form.
- Link reference to Discussions