### PR TITLE
Add Azure DevOps MCP Server

### DIFF
--- a/servers/azure-devops/icon.svg
+++ b/servers/azure-devops/icon.svg
@@ -1,0 +1,2 @@
+<svg width="800px" height="800px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="none"><path fill="currentColor" d="M15 3.622v8.512L11.5 15l-5.425-1.975v1.958L3.004 10.97l8.951.7V4.005L15 3.622zm-2.984.428L6.994 1v2.001L2.382 4.356 1 6.13v4.029l1.978.873V5.869l9.038-1.818z"/></svg>
+

--- a/servers/azure-devops/server.json
+++ b/servers/azure-devops/server.json
@@ -1,0 +1,19 @@
+{
+  "name": "Azure DevOps",
+  "description": "Interact with Azure DevOps work items, pull requests, builds, and releases.",
+  "transport": [
+    "stdio"
+  ],
+  "icon": "./icon.svg",
+  "oauth": false,
+  "config": {
+    "command": "npx",
+    "args": [
+      "-y",
+      "@azure-devops/mcp",
+      "{organization}"
+    ]
+  },
+  "documentation": "https://github.com/microsoft/azure-devops-mcp/blob/main/docs/GETTINGSTARTED.md"
+}
+

--- a/servers/index.json
+++ b/servers/index.json
@@ -54,5 +54,6 @@
   "astro",
   "mercado-pago",
   "mercado-libre",
-  "render"
+  "render",
+  "azure-devops"
 ]


### PR DESCRIPTION
Closes #52

Adds the Azure DevOps MCP Server to the directory.

- Server name: Azure DevOps
- Repository: https://github.com/microsoft/azure-devops-mcp
- Icon: SVG with currentColor fill
- Configuration: npx with @azure-devops/mcp package