### PR TITLE
Update add-server.md with documentation URL instructions

### DIFF
--- a/.cursor/commands/add-server.md
+++ b/.cursor/commands/add-server.md
@@ -4,4 +4,6 @@ There's an attached file in the issue for the icon.
 
 If the server icon has hardcoded fill colors, replace them `currentColor`
 
+If a url was provided under "Documentation URL (if applicable)", then include this url in a top-level "docs" field in the server.json that you create.
+
 Add the server to the bottom of `index.json`


### PR DESCRIPTION
make it so that add-server.md also includes documentation URLs in server.json, if they are provided in the Issue / MCP server proposal