### PR TITLE
Change CodeScene command from docker to npx

### DIFF
--- a/servers/codescene/server.json
+++ b/servers/codescene/server.json
@@ -6,17 +6,10 @@
   ],
   "icon": "./icon.svg",
   "config": {
-    "command": "docker",
+    "command": "npx",
     "args": [
-      "run",
-      "-i",
-      "--rm",
-      "-e",
-      "CS_ACCESS_TOKEN",
-      "codescene/codescene-mcp"
-    ],
-    "env": {
-      "CS_ACCESS_TOKEN": ""
-    }
+      "-y",
+      "@codescene/codehealth-mcp"
+    ]
   }
 }


### PR DESCRIPTION
Updated command to use `npx` instead of Docker. Also, the new NPM-based MCP does not need ENV vars and can be configured through the MCP's own `set_config` tool.